### PR TITLE
Make IP label clearer

### DIFF
--- a/nodes/Hikvision-config.html
+++ b/nodes/Hikvision-config.html
@@ -115,7 +115,7 @@
     </div>
     <div class="form-row">
         <label for="node-config-input-host">
-            <i class="fa fa-server"></i> Server IP
+            <i class="fa fa-server"></i> Camera IP
         </label>
         <input type="text" id="node-config-input-host" placeholder="">
     </div>


### PR DESCRIPTION
From a noob standpoint, there's no documentation on how to set the config node, but there are inferences to a DVR-type server, as if the camera is a part of a system that has a central server where recordings are stored, which makes a noob question what should go in the IP field, especially if they've made a config mistake somewhere that prevents a successful connection to the camera.  So I thought changing "Server IP" to "Camera IP" might be just enough to assure a noob like me that they are correctly configuring the config node.

If this is inappropriate in other contexts, then a section in the readme explaining how to set up the config node might be helpful.