### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,6 +636,7 @@ msg = {
 <br/>
 
 # HIKVISION AND OTHER HIK BASED DEVICES, TESTED WITH THE NODE
+It seems to be filled in by the autodetect function in nodered, though it does not prove functionaluty. KD8003-ime1 for example does not work without modifications.
 This is a list of Hikvision (and hik compatible) models the users own and decided to share because it checked working with Hikvision-Ultimate. <br/>
 This is only a partial model list. Hikvision-Ultimate should work with basically ALL Hikvision devices.<br/>
 [Click HERE to view the list of tested devices](http://80.211.147.27:8080/?read=true&md=noCD&fw=no) 


### PR DESCRIPTION
Hi, I commented the readme in a fork just for the sake of simplicity.
Just wanted to chime in to say that the autodetect function in nodered only checks if the connection is successful, not if the commands work with the device. Specifically kd8003 series of modular intercoms.
If you are interested, there is some activity going on to make a module in homeassistant, but more intruiguing is the fact that the intercom kd8003-ime1 apparently needs more parameters passed to work/accept commands (eg room number, floor...)
https://community.home-assistant.io/t/ds-kd8003-ds-kv8113-ds-kv8213-ds-kv6113-ds-kv8413-and-integration-hikvision-hikconnect-video-intercom-doorbell/238535/1172
